### PR TITLE
Fix trade corner bug. Pokemon data must be base64 encoded

### DIFF
--- a/core/pokemon/func.php
+++ b/core/pokemon/func.php
@@ -10,9 +10,7 @@ function decodeExchange ($stream, $pkm = true, $region) {
     $decData["offer_species"] = hexdec(bin2hex(fread($postdata, 0x1))); // $23 Offered Pokémon’s species
     $decData["req_gender"] = bin2hex(fread($postdata, 0x1)); // $24 Requested Pokémon’s gender
     $decData["req_species"] = hexdec(bin2hex(fread($postdata, 0x1))); // $25 Requested Pokémon’s species
-	$decData["trainer_name"] = fread($postdata, $region == "j" ? 0x5 : 0x7); // $26 Name of trainer who requests the trade
-    $decData["pokemon_data"] = $pkm ? fread($postdata, $region == "j" ? 0x0 : 0x41) : NULL; // $2B Pokémon data
-	$decData["mail_data"] = fread($postdata, $region == "j" ? 0x0 : 0x2F); // $2B Held mail data
+	$decData["b64_pokemon"] = base64_encode(fread($postdata, $region == "j" ? 0x69 : 0x78)); // Base64 of the Pokemon that needs to be sent back in email
     // These bytes (except for b64_pokemon) are all that the web scripts need to deal with.
     return $decData;
 }

--- a/core/pokemon/trade_corner.php
+++ b/core/pokemon/trade_corner.php
@@ -12,10 +12,12 @@
 		//$stmt->bind_param("s",$decoded_data["email"]);
 		//$stmt->execute();
 
+		$pkm_file =
+
 		// Now, begin adding the new trade data...
-		$stmt = $db->prepare("INSERT INTO `bxt".$game_region."_exchange` (email, trainer_id, secret_id, offer_gender, offer_species, request_gender, request_species, trainer_name, pokemon_data, mail_data) VALUES (?,?,?,?,?,?,?,?,?,?)");
+		$stmt = $db->prepare("INSERT INTO `bxt".$game_region."_exchange` (email, trainer_id, secret_id, offer_gender, offer_species, request_gender, request_species, base64_pokemon) VALUES (?,?,?,?,?,?,?,?)");
 
 		// Bind the parameters. REMEMBER: Pokémon Species are the DECIMAL index, not hex!
-		$stmt->bind_param("siisisisss",$decoded_data["email"],$decoded_data["trainer_id"],$decoded_data["secret_id"],$decoded_data["offer_gender"],$decoded_data["offer_species"],$decoded_data["req_gender"],$decoded_data["req_species"],$decoded_data["trainer_name"],$decoded_data["pokemon_data"],$decoded_data["mail_data"]);
+		$stmt->bind_param("siisisis",$decoded_data["email"],$decoded_data["trainer_id"],$decoded_data["secret_id"],$decoded_data["offer_gender"],$decoded_data["offer_species"],$decoded_data["req_gender"],$decoded_data["req_species"],$decoded_data["base64_pokemon"]);
 		$stmt->execute();
 	}


### PR DESCRIPTION
Pokemon crystal expects the data for the pokemon to be base64 encoded. The splits for trainer_name,pokemon_data, and mail_data were removed as they are not needed.