### PR TITLE
[web] Use PHPMailer instead of mail()

### DIFF
--- a/web/classes/UserUtil.php
+++ b/web/classes/UserUtil.php
@@ -1,4 +1,8 @@
 <?php
+	use PHPMailer\PHPMailer\PHPMailer;
+	use PHPMailer\PHPMailer\Exception;
+
+	require_once dirname(__DIR__)."/vendor/autoload.php";
 	require_once("DBUtil.php");
 	require_once("ConfigUtil.php");
 	require_once("TemplateUtil.php");
@@ -157,14 +161,15 @@
 		}
 		
 		private function sendUtf8Email($to, $from, $subject, $message) {
-			$utf8_subject = "=?UTF-8?B?".base64_encode($subject)."?=";
-			$utf8_message = base64_encode($message);
-			$headers = [
-				"From" => $from,
-				"Content-Type" => "text/html; charset=utf-8",
-				"Content-Transfer-Encoding" => "base64"
-			];
-			mail($to, $utf8_subject, $utf8_message, $headers);
+			$mail = new PHPMailer();
+			$mail->CharSet = PHPMailer::CHARSET_UTF8;
+			$mail->Encoding = PHPMailer::ENCODING_QUOTED_PRINTABLE;
+			$mail->isSendmail();
+			$mail->setFrom($from);
+			$mail->addAddress($to);
+			$mail->Subject = $subject;
+			$mail->msgHTML($message);
+			$mail->send();
 		}
 		
 		public function resetPassword($id, $key, $password, $passwordConfirm) {

--- a/web/composer.json
+++ b/web/composer.json
@@ -1,5 +1,6 @@
 {
     "require": {
-        "twig/twig": "^3.0"
+        "twig/twig": "^3.0",
+        "phpmailer/phpmailer": "^6.9"
     }
 }

--- a/web/composer.lock
+++ b/web/composer.lock
@@ -4,8 +4,89 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6a6772df2521c6860a448e9115f2793a",
+    "content-hash": "b001b19aa6c22f883ab29c6d3a93b9ed",
     "packages": [
+        {
+            "name": "phpmailer/phpmailer",
+            "version": "v6.9.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPMailer/PHPMailer.git",
+                "reference": "039de174cd9c17a8389754d3b877a2ed22743e18"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPMailer/PHPMailer/zipball/039de174cd9c17a8389754d3b877a2ed22743e18",
+                "reference": "039de174cd9c17a8389754d3b877a2ed22743e18",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-filter": "*",
+                "ext-hash": "*",
+                "php": ">=5.5.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+                "doctrine/annotations": "^1.2.6 || ^1.13.3",
+                "php-parallel-lint/php-console-highlighter": "^1.0.0",
+                "php-parallel-lint/php-parallel-lint": "^1.3.2",
+                "phpcompatibility/php-compatibility": "^9.3.5",
+                "roave/security-advisories": "dev-latest",
+                "squizlabs/php_codesniffer": "^3.7.2",
+                "yoast/phpunit-polyfills": "^1.0.4"
+            },
+            "suggest": {
+                "decomplexity/SendOauth2": "Adapter for using XOAUTH2 authentication",
+                "ext-mbstring": "Needed to send email in multibyte encoding charset or decode encoded addresses",
+                "ext-openssl": "Needed for secure SMTP sending and DKIM signing",
+                "greew/oauth2-azure-provider": "Needed for Microsoft Azure XOAUTH2 authentication",
+                "hayageek/oauth2-yahoo": "Needed for Yahoo XOAUTH2 authentication",
+                "league/oauth2-google": "Needed for Google XOAUTH2 authentication",
+                "psr/log": "For optional PSR-3 debug logging",
+                "symfony/polyfill-mbstring": "To support UTF-8 if the Mbstring PHP extension is not enabled (^1.2)",
+                "thenetworg/oauth2-azure": "Needed for Microsoft XOAUTH2 authentication"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PHPMailer\\PHPMailer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-2.1-only"
+            ],
+            "authors": [
+                {
+                    "name": "Marcus Bointon",
+                    "email": "phpmailer@synchromedia.co.uk"
+                },
+                {
+                    "name": "Jim Jagielski",
+                    "email": "jimjag@gmail.com"
+                },
+                {
+                    "name": "Andy Prevost",
+                    "email": "codeworxtech@users.sourceforge.net"
+                },
+                {
+                    "name": "Brent R. Matzelle"
+                }
+            ],
+            "description": "PHPMailer is a full-featured email creation and transfer class for PHP",
+            "support": {
+                "issues": "https://github.com/PHPMailer/PHPMailer/issues",
+                "source": "https://github.com/PHPMailer/PHPMailer/tree/v6.9.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Synchro",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-11-25T22:23:28+00:00"
+        },
         {
             "name": "symfony/polyfill-ctype",
             "version": "v1.27.0",
@@ -251,5 +332,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
PHP's `mail()` function isn't the most secure and requires manually setting several headers in order to get through most spam filters.

This change updates it to use [PHPMailer](https://github.com/PHPMailer/PHPMailer) instead, which sets the appropriate headers while also handling proper encoding of the subject and body when required.

I also switched the encoding from `base64` to `quoted-printable` to make it appear less spammy to filters

Spam report from my rspamd mail filter using `mail()`.
The spam score was just 0.6 points away from being rejected outright by may mail server!!
![image](https://github.com/REONTeam/reon/assets/1270500/05e2cc8c-7d8c-4fe4-84b2-ccc2d5e83e56)

Spam report after switch to PHPMailer
![image](https://github.com/REONTeam/reon/assets/1270500/ab40cde3-2f90-4a08-a00e-e9760190350b)

The complaints about the service account are due to it using sendmail in both instances, but PHPMailer makes it easy to switch to a proper external SMTP server later down the line. 