### PR TITLE
Fix user registration flow

### DIFF
--- a/web/classes/UserUtil.php
+++ b/web/classes/UserUtil.php
@@ -273,7 +273,7 @@
 			$dion_ppp_id = self::$instance->generatePPPId();
 			$log_in_password = self::$instance->generateLogInPassword();
 			$db = DBUtil::getInstance()->getDB();
-			$stmt = $db->prepare("insert into sys_users (email, password, dion_ppp_id, dion_email_local, log_in_password) values (?)");
+			$stmt = $db->prepare("insert into sys_users (email, password, dion_ppp_id, dion_email_local, log_in_password, money_spent) values (?,?,?,?,?,0)");
 			$stmt->bind_param("sssss", $email, $password_hash, $dion_ppp_id, $reonEmail, $log_in_password);
 			$stmt->execute();
 			

--- a/web/htdocs/signup_cont.php
+++ b/web/htdocs/signup_cont.php
@@ -18,7 +18,7 @@
 			$email = UserUtil::getInstance()->verifySignupRequest($_GET["id"], $_GET["key"]);
 			if (isset($email)) {
 				echo TemplateUtil::render("signup_cont", [
-					"result" => 0,
+					"result" => -1,
 					"id" => $_GET["id"],
 					"key" => $_GET["key"],
 					"email" => $email


### PR DESCRIPTION
I've updated `signup_cont.php` to set result to `-1` since the template uses `0` to indicate that registration is successful, which isn't true at this point in time. Positive numbers were already used to indicate validation errors, so I opted for a negative value instead.

`money_spent` doesn't have a default value configured on the column. While I could have updated `tables.sql`, I felt being explicit in this scenario was more appropriate.