### PR TITLE
Add Battle Tower room and leaders rewrites for nginx

### DIFF
--- a/examples/nginx/default.conf.template
+++ b/examples/nginx/default.conf.template
@@ -11,6 +11,20 @@ server {
     index  index.php index.html index.htm;
     
 
+    # Battle Tower dynamic routing. The Apache .htaccess (web/htdocs/cgb/.htaccess)
+    # rewrites roomNNNN.cgb -> room.cgb?room=NNNN (and leadersNNNN.cgb likewise),
+    # but nginx ignores .htaccess, so without this Battle Tower rooms 404 on the
+    # Docker/nginx setup. Exact-match location avoids the "if + try_files" pitfall.
+    location = /cgb/download {
+        if ($arg_name ~ "^/01/CGB-BXT([A-Z])/battle/room(....)\.cgb$") {
+            set $args "name=/01/CGB-BXT$1/battle/room.cgb&room=$2";
+        }
+        if ($arg_name ~ "^/01/CGB-BXT([A-Z])/battle/leaders(....)\.cgb$") {
+            set $args "name=/01/CGB-BXT$1/battle/leaders.cgb&room=$2";
+        }
+        rewrite ^ /cgb/download.php last;
+    }
+
     location /cgb/ {
         try_files $uri $uri/ @extensionless-php;
     }


### PR DESCRIPTION
### Problem

On the Docker setup, Battle Tower room and leaders downloads currently return a 404 error. The client requests `.../battle/roomNNNN.cgb` and `.../battle/leadersNNNN.cgb`, which need to map to `room.cgb`/`leaders.cgb` with the room number as a `room` query parameter. `web/htdocs/cgb/.htaccess` handles this for Apache, but nginx does not read `.htaccess` and the example nginx config had no equivalent, so these requests fall through to a 404.

### Change

Adds an exact-match `location = /cgb/download` that rewrites the two patterns and hands off to `download.php`. An exact-match location is used so the rewrite does not have to share a block with `try_files`.

### Testing

Brought the stack up from the example docker compose and confirmed against a real Pokemon Crystal client (BGB + libmobile):

- `roomNNNN.cgb` returns a 1484-byte room instead of 404
- `leadersNNNN.cgb` returns the honor roll
- `rooms.cgb` (the count) still works, so no regression to the existing routing