### PR TITLE
Fix web service in docker setup

### DIFF
--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -47,6 +47,9 @@ services:
     volumes:
       - ./config.json:/var/www/reon/config.json:ro
       - ./web/:/var/www/reon/web
+      # Preserve composer deps built into the image; the bind mount above would
+      # otherwise shadow vendor/ (breaking the website + scripts/add_user.php).
+      - /var/www/reon/web/vendor
     tmpfs:
       - /tmp/reon
     depends_on:


### PR DESCRIPTION
### Problem

The `web` service bind-mounts `./web` to `/var/www/reon/web`. That mount shadows the `vendor/` directory that the image builds with `composer install`, so at runtime `vendor/autoload.php` is missing. The website and CLI scripts such as `scripts/add_user.php` fail with a fatal "Failed to open vendor/autoload.php".

### Change

Adds an anonymous volume for `/var/www/reon/web/vendor` on the `web` service so the image's installed dependencies are preserved on top of the bind mount. This is the standard pattern for bind-mounting source over a directory that also contains build output.

### Testing

With this change the site loads and `add_user.php` runs on a fresh `docker compose up`, with no manual `composer install` on the host.