### PR TITLE
Small CSS tweaks

### DIFF
--- a/web/htdocs/css/main.css
+++ b/web/htdocs/css/main.css
@@ -1,3 +1,5 @@
+body { margin: 12px; }
+
 .cgb-gradient-border {
   border-image: linear-gradient(to right, rgba(0, 0, 0, 0), #b80a41, #4e4ba8, #6eb122, #daac06, #00938a, rgba(0, 0, 0, 0)) 1;
   border-width: 0 0 3px 0;

--- a/web/htdocs/css/mariokart.css
+++ b/web/htdocs/css/mariokart.css
@@ -74,8 +74,6 @@ body.mariokart-theme > main {
   font-size: 64px !important;
   line-height: 64px !important;
   color: #ff9408;
-  -webkit-text-stroke: 0;
-  paint-order: stroke fill;
   text-shadow:
     4px 0 0 #6b0094,
     -4px 0 0 #6b0094,
@@ -88,7 +86,7 @@ body.mariokart-theme > main {
 }
 
 .mkgba-table {
-  width: 100%;
+  min-width: 100%;
   border-collapse: collapse;
   table-layout: fixed;
   background: #ffffff;
@@ -102,8 +100,6 @@ body.mariokart-theme > main {
   font-size: 16px !important;
   line-height: 16px !important;
   color: #a5f7ff;
-  -webkit-text-stroke: 0;
-  paint-order: stroke fill;
   text-shadow:
     1px 0 0 #212952,
     -1px 0 0 #212952,
@@ -119,7 +115,6 @@ body.mariokart-theme > main {
   color: #ff9408;
   font-size: 32px !important;
   line-height: 32px !important;
-  -webkit-text-stroke: 0;
   text-shadow:
     2px 0 0 #6b0094,
     -2px 0 0 #6b0094,
@@ -187,25 +182,27 @@ body.mariokart-theme > main {
     max-width: 100%;
   }
 
-  .mkgba-title {
+  /*.mkgba-title {
     font-size: 32px !important;
     line-height: 32px !important;
-    -webkit-text-stroke: 0;
     text-shadow:
-      4px 0 0 #6b0094,
-      -4px 0 0 #6b0094,
-      0 4px 0 #6b0094,
-      0 -4px 0 #6b0094,
-      4px 4px 0 #6b0094,
-      -4px 4px 0 #6b0094,
-      4px -4px 0 #6b0094,
-      -4px -4px 0 #6b0094;
-  }
+      2px 0 0 #6b0094,
+      -2px 0 0 #6b0094,
+      0 2px 0 #6b0094,
+      0 -2px 0 #6b0094,
+      2px 2px 0 #6b0094,
+      -2px 2px 0 #6b0094,
+      2px -2px 0 #6b0094,
+      -2px -2px 0 #6b0094;
+  }*/
+  
+  main#content { overflow: auto; }
+  /*.mkgba-table { width: auto; }*/
 
   .mkgba-table th,
   .mkgba-table td {
-    font-size: clamp(12px, 3.2vw, 16px) !important;
-    line-height: 1.15 !important;
+    /*font-size: clamp(12px, 3.2vw, 16px) !important;
+    line-height: 1.15 !important;*/
     padding: 5px 6px;
     white-space: normal !important;
     word-break: keep-all !important;
@@ -214,7 +211,7 @@ body.mariokart-theme > main {
     vertical-align: middle;
   }
 
-  .mkgba-table thead th {
+  /*.mkgba-table thead th {
     font-size: clamp(12px, 3.4vw, 16px) !important;
     line-height: 1.15 !important;
     text-shadow:
@@ -226,7 +223,7 @@ body.mariokart-theme > main {
       -2px 2px 0 #6b0094,
       2px -2px 0 #6b0094,
       -2px -2px 0 #6b0094;
-  }
+  }*/
 
   .mkgba-table {
     table-layout: fixed;


### PR DESCRIPTION
Added a 12px "breathability" space for every page. Also fixed up the Mario Kart page, which had poor text resizing and a stray styling rule that made the text borders disappear in Safari.